### PR TITLE
Move user.sh to last to be loaded, so it can override default definitions

### DIFF
--- a/files/.zsh/init.sh
+++ b/files/.zsh/init.sh
@@ -1,7 +1,6 @@
 export DOTFILES_LOADED="true"
 export SHELL_NAME="zsh"
 
-source $HOME/.zsh/user.sh
 source $HOME/.zsh/exports.sh
 source $HOME/.zsh/specific.sh
 source $HOME/.zsh/other.sh
@@ -20,3 +19,4 @@ source $HOME/.zsh/go.sh
 source $HOME/.zsh/aliases.sh
 source $HOME/.zsh/heroku.sh
 source $HOME/.zsh/zsh-plugins.sh
+source $HOME/.zsh/user.sh


### PR DESCRIPTION
If a user wants to override a setting (let's say, PATH environment variable), it is not currently possible because it is overwritten by some other shell script along the load process. Making user.sh the last to be loaded, the user get's this freedom without having future updates to break their own configuration.